### PR TITLE
feat: Add 5-tap toggle feature for mobile users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # MetaScan: Lightweight Webpage Metadata Extraction Tool
 
-MetaScan is a lightweight (29.9 kB) client-side JavaScript tool that extracts and visualizes metadata from any webpage via a simple script tag. It provides an intuitive UI to analyze metadata including basic meta tags, Open Graph, Twitter Cards, and technical metadata.
+MetaScan is a lightweight (29.9 kB) client-side JavaScript tool that extracts and visualizes metadata from any webpage via a simple script tag. It provides an intuitive UI to analyze and offer insights into basic meta tags, Open Graph, Twitter Cards, and technical metadata.
+
+## Why Choose MetaScan?
+
+✨ **Immediate Visibility** - Get instant access to all webpage metadata without leaving your site  
+⚡ **Fast Performance** - Minimal footprint (29.9 kB) with zero dependencies  
+🛠️ **Developer Friendly** - Perfect for debugging, testing, and validating metadata implementations  
+🔄 **SEO Insights** - Identify and fix metadata issues that impact search rankings  
+🌗 **Clean UI** - Modern interface with dark/light mode  
+🔒 **Client-Side Only** - No data sent to servers, works offline and respects privacy  
 
 ## Features
 
@@ -11,7 +20,42 @@ MetaScan is a lightweight (29.9 kB) client-side JavaScript tool that extracts an
 - 🎛️ Configurable positioning on any corner of the screen
 - 📋 Copy functionality for metadata values
 - 🧩 Structured data extraction (JSON-LD and Microdata)
+- 🔎 Search and filter functionality across all metadata categories
 - 📱 Mobile-friendly with 5-tap toggle feature
+
+## Who Is MetaScan For?
+
+MetaScan is designed to serve the needs of various professionals working with web content:
+
+### Web Developers
+- **Verify Metadata Implementation** - Instantly check metadata implementation during development
+- **Solve Structured Data Issues** - Resolve structured data problems without external tools
+- **Implement Open Graph and Twitter Card Tags** - Ensure correct implementation of Open Graph and Twitter Card tags
+- **Test Responsive Behavior** - Test metadata responsiveness across all devices
+
+### SEO Specialists
+- **Audit Metadata** - Get complete visibility into metadata completeness and accuracy
+- **Verify Structured Data** - Check JSON-LD and Microdata implementation with a single click
+- **Optimize Social Sharing** - Improve Open Graph and Twitter Card implementations for better engagement
+- **Protect Search Rankings** - Identify metadata issues that could harm search rankings
+
+### Content Managers
+- **Preview Social Sharing** - See how content will appear when shared on social platforms
+- **Ensure Proper Metadata** - Check metadata before content goes live
+- **Maintain Brand Consistency** - Verify metadata consistency across the website
+- **Document Metadata** - Copy metadata for reporting and collaboration
+
+### Technical Marketers
+- **Optimize Landing Pages** - Fine-tune landing pages for better social sharing and SEO impact
+- **Verify Campaign Parameters** - Check campaign tracking parameters and metadata
+- **Ensure Brand Consistency** - Maintain brand consistency across digital properties
+- **Test Metadata Changes** - Validate metadata changes without developer assistance
+
+### QA Testers
+- **Validate Metadata** - Easily validate metadata against project requirements
+- **Detect Errors** - Catch structured data implementation errors before they reach production
+- **Verify Consistency** - Check metadata consistency across different page templates
+- **Streamline Testing** - Integrate metadata validation into existing testing workflows
 
 ## Installation
 
@@ -161,13 +205,33 @@ export interface MicrodataItem {
 
 ## Structured Data Extraction
 
-MetaScan now extracts structured data from webpages, including:
+MetaScan extracts structured data from webpages, including:
 
 1. **JSON-LD**: Extracts all JSON-LD scripts from the page, which are commonly used for rich search results.
 
 2. **Microdata**: Extracts HTML microdata annotations, providing insights into how search engines interpret your content.
 
 This makes MetaScan an invaluable tool for SEO professionals and developers who need to debug structured data implementations.
+
+## Search and Filter Functionality
+
+MetaScan includes a powerful search feature that allows you to quickly find specific metadata:
+
+- **Keyboard Shortcuts**: Press `Ctrl+F` (Windows/Linux) or `Cmd+F` (Mac) to focus the search input
+- **Real-time Filtering**: Results update as you type across all metadata categories
+- **Clear Search**: Use the clear button or press `Escape` to reset the search
+- **No Results Indication**: Clear messaging when search filters out all items
+
+This feature makes it easy to locate specific metadata in content-rich pages.
+
+## UI Improvements
+
+The MetaScan interface has been redesigned for better usability:
+
+- **Integrated Header Controls**: All controls (position, settings, theme toggle, JSON view) are now in a single header
+- **Simplified Layout**: Cleaner component structure with logical separation of concerns
+- **Improved Dropdown Positioning**: Dropdowns now correctly position based on panel location
+- **Enhanced Error Handling**: Robust error handling for structured data extraction with detailed logging
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MetaScan is a lightweight (29.9 kB) client-side JavaScript tool that extracts an
 - 🎛️ Configurable positioning on any corner of the screen
 - 📋 Copy functionality for metadata values
 - 🧩 Structured data extraction (JSON-LD and Microdata)
+- 📱 Mobile-friendly with 5-tap toggle feature
 
 ## Installation
 
@@ -64,6 +65,32 @@ window.MetaScan.enableOrDisable(true);
 const metadata = window.MetaScan.getMetadata();
 console.log(metadata);
 ```
+
+You can also enable or disable MetaScan without JavaScript by using the 5-tap feature described in the [Mobile-Friendly Features](#mobile-friendly-features) section.
+
+## Mobile-Friendly Features
+
+### 5-Tap Toggle
+
+MetaScan can be enabled or disabled by tapping anywhere on the page 5 times in quick succession (within 3 seconds). This is particularly useful on mobile devices where accessing the console is not practical.
+
+As you tap, a subtle indicator will show your progress toward the 5 taps required to toggle the state. When the sequence is completed, a toast notification will confirm that MetaScan has been enabled or disabled.
+
+#### How to Use the 5-Tap Feature:
+
+1. **Tap anywhere on the page** 5 times within 3 seconds
+2. After every other tap, you'll see a toast notification showing your progress
+3. After the 5th tap, MetaScan will toggle between enabled and disabled states
+4. A confirmation toast will appear showing "MetaScan enabled" or "MetaScan disabled"
+
+#### Troubleshooting:
+
+- Make sure to complete all 5 taps within the 3-second window
+- Tap on any part of the page (not just the document body)
+- If you're having trouble, try tapping on empty areas of the page
+- Check your browser console for log messages (useful for developers)
+
+This feature works as a toggle - if MetaScan is currently enabled, the 5-tap sequence will disable it, and vice versa.
 
 ## Extracted Metadata
 
@@ -145,6 +172,3 @@ This makes MetaScan an invaluable tool for SEO professionals and developers who 
 ## License
 
 MIT
-
-..
-..

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { renderUI } from "./ui";
 import { logger } from "./utils/logger";
 import { extractMetadata } from "./core";
 import { stateManager } from "./state";
+import { initTapDetector } from "./utils/tap-detector";
 
 // Default options
 const defaultOptions: MetaScanOptions = {
@@ -40,6 +41,9 @@ export function enableOrDisable(enabled: boolean): void {
     } else {
       // If container exists but is hidden, show it
       container.style.display = "";
+      
+      // Also update the UI state to open the panel
+      stateManager.updateState({ isOpen: true });
     }
 
     // Re-initialize DOM watcher if it was disabled
@@ -57,6 +61,9 @@ export function enableOrDisable(enabled: boolean): void {
     if (container) {
       // Hide UI
       container.style.display = "none";
+      
+      // Also update the UI state to close the panel
+      stateManager.updateState({ isOpen: false });
     }
 
     // Clean up DOM watcher
@@ -73,6 +80,9 @@ export function init(userOptions?: Partial<MetaScanOptions>): void {
   }
 
   logger.info("MetaScan initialized with options:", options);
+  
+  // Initialize the tap detector for mobile usage
+  initTapDetector();
 }
 
 /**

--- a/src/ui/components/Toast.tsx
+++ b/src/ui/components/Toast.tsx
@@ -1,0 +1,98 @@
+import { h, JSX } from "preact";
+import { useState, useEffect } from "preact/hooks";
+import { cn } from "../../utils/cn";
+
+interface ToastProps {
+  message: string;
+  duration?: number;
+  type?: "info" | "success" | "error";
+  onClose?: () => void;
+}
+
+export function Toast({ 
+  message, 
+  duration = 3000, 
+  type = "info", 
+  onClose 
+}: ToastProps): JSX.Element {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+      if (onClose) {
+        setTimeout(onClose, 300); // Allow animation to complete
+      }
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  const typeClasses = {
+    info: "bg-blue-500",
+    success: "bg-green-500",
+    error: "bg-red-500"
+  };
+
+  return (
+    <div
+      className={cn(
+        "fixed z-50 bottom-4 left-1/2 transform -translate-x-1/2",
+        "px-4 py-2 rounded-lg shadow-lg text-white text-sm",
+        "transition-all duration-300",
+        typeClasses[type],
+        visible ? "opacity-90" : "opacity-0 translate-y-2"
+      )}
+    >
+      {message}
+    </div>
+  );
+}
+
+// Global toast management
+let toastContainer: HTMLDivElement | null = null;
+let currentToast: any = null;
+
+export function showToast(message: string, type: "info" | "success" | "error" = "info", duration = 3000) {
+  // Create container if it doesn't exist
+  if (!toastContainer) {
+    toastContainer = document.createElement("div");
+    toastContainer.id = "meta-scan-toast-container";
+    document.body.appendChild(toastContainer);
+  }
+
+  // Clear any existing toast
+  if (currentToast) {
+    document.body.removeChild(toastContainer);
+    toastContainer = document.createElement("div");
+    toastContainer.id = "meta-scan-toast-container";
+    document.body.appendChild(toastContainer);
+  }
+
+  // Create a simple toast element
+  const toast = document.createElement("div");
+  toast.className = `fixed z-50 bottom-4 left-1/2 transform -translate-x-1/2 
+                     px-4 py-2 rounded-lg shadow-lg text-white text-sm
+                     transition-all duration-300 opacity-90
+                     ${type === 'info' ? 'bg-blue-500' : type === 'success' ? 'bg-green-500' : 'bg-red-500'}`;
+  toast.textContent = message;
+  
+  // Add to container
+  toastContainer.appendChild(toast);
+  currentToast = toast;
+  
+  // Remove after duration
+  setTimeout(() => {
+    if (toast && toastContainer) {
+      toast.style.opacity = "0";
+      toast.style.transform = "translate(-50%, 10px)";
+      
+      setTimeout(() => {
+        if (toastContainer && toastContainer.contains(toast)) {
+          toastContainer.removeChild(toast);
+        }
+        currentToast = null;
+      }, 300);
+    }
+  }, duration);
+}

--- a/src/utils/tap-detector.ts
+++ b/src/utils/tap-detector.ts
@@ -1,0 +1,105 @@
+/**
+ * Utility to detect multiple taps for enabling/disabling MetaScan
+ */
+import { enableOrDisable } from "..";
+import { stateManager } from "../state";
+import { logger } from "./logger";
+import { showToast } from "../ui/components/Toast";
+
+// Configuration
+const TAP_COUNT_THRESHOLD = 5;
+const TAP_TIMEOUT_MS = 3000; // 3 seconds to complete the sequence
+
+// State
+let tapCount = 0;
+let lastTapTime = 0;
+let tapTimeoutId: number | null = null;
+
+/**
+ * Reset the tap counter
+ */
+function resetTapCounter() {
+  tapCount = 0;
+  if (tapTimeoutId !== null) {
+    window.clearTimeout(tapTimeoutId);
+    tapTimeoutId = null;
+  }
+}
+
+/**
+ * Handle a tap event
+ * @returns {boolean} Whether the tap sequence was completed
+ */
+export function handleTap(): boolean {
+  const now = Date.now();
+  
+  // If it's been too long since the last tap, reset the counter
+  if (now - lastTapTime > TAP_TIMEOUT_MS && tapCount > 0) {
+    resetTapCounter();
+  }
+  
+  // Update last tap time
+  lastTapTime = now;
+  
+  // Increment tap count
+  tapCount++;
+  
+  // Show a subtle indicator for taps after the first one
+  if (tapCount > 1 && tapCount < TAP_COUNT_THRESHOLD) {
+    // Only show the indicator every other tap to avoid too many notifications
+    if (tapCount % 2 === 0) {
+      showToast(`${TAP_COUNT_THRESHOLD - tapCount} more taps to toggle MetaScan`, "info", 1000);
+    }
+  }
+  
+  // Set a timeout to reset the counter if the sequence isn't completed
+  if (tapTimeoutId === null) {
+    tapTimeoutId = window.setTimeout(() => {
+      resetTapCounter();
+    }, TAP_TIMEOUT_MS);
+  }
+  
+  // Check if we've reached the threshold
+  if (tapCount >= TAP_COUNT_THRESHOLD) {
+    // Toggle the enabled state
+    const currentState = stateManager.getEnableDisable();
+    const newState = !currentState;
+    
+    // Log the action
+    logger.info(`MetaScan: 5-tap sequence detected, ${newState ? 'enabling' : 'disabling'} MetaScan`);
+    
+    // Show a toast notification
+    showToast(`MetaScan ${newState ? 'enabled' : 'disabled'}`, newState ? 'success' : 'info', 2000);
+    
+    // Reset the counter
+    resetTapCounter();
+    
+    // Toggle the state
+    enableOrDisable(newState);
+    
+    // Return true to indicate the sequence was completed
+    return true;
+  }
+  
+  return false;
+}
+
+/**
+ * Initialize the tap detector
+ */
+export function initTapDetector() {
+  // Only initialize in browser environment
+  if (typeof window === 'undefined') return;
+  
+  // Add a click event listener to the document
+  document.addEventListener('click', () => {
+    // Process all clicks, not just those on the document body
+    // This makes the feature more reliable, especially on mobile
+    handleTap();
+    
+    // Log for debugging
+    logger.info('MetaScan: Tap detected, count: ' + tapCount);
+  });
+  
+  logger.info('MetaScan: Tap detector initialized');
+}

--- a/test-page.html
+++ b/test-page.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MetaScan Test Page</title>
+    <meta name="description" content="A test page for MetaScan with 5-tap feature">
+    <meta name="author" content="Test User">
+    <meta name="keywords" content="test, meta, scan">
+    
+    <!-- Open Graph tags -->
+    <meta property="og:title" content="MetaScan Test Page">
+    <meta property="og:description" content="Testing the MetaScan extension">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://example.com">
+    
+    <!-- Twitter Card tags -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="MetaScan Test Page">
+    <meta name="twitter:description" content="Testing the MetaScan extension">
+    
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1 {
+            color: #333;
+        }
+        .instructions {
+            background-color: #f8f9fa;
+            border-left: 4px solid #007bff;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        .tap-area {
+            background-color: #e9ecef;
+            border-radius: 8px;
+            padding: 40px;
+            text-align: center;
+            margin: 30px 0;
+            cursor: pointer;
+        }
+        code {
+            background-color: #f1f1f1;
+            padding: 2px 4px;
+            border-radius: 4px;
+            font-family: monospace;
+        }
+    </style>
+</head>
+<body>
+    <h1>MetaScan 5-Tap Test Page</h1>
+    
+    <div class="instructions">
+        <h2>Instructions:</h2>
+        <p>This page is set up to test the MetaScan 5-tap feature. Here's how to use it:</p>
+        <ol>
+            <li>MetaScan should be active on this page (look for the icon in one of the corners)</li>
+            <li>To toggle MetaScan on/off, tap anywhere on the document body 5 times within 3 seconds</li>
+            <li>You should see toast notifications showing your progress</li>
+            <li>After the 5th tap, MetaScan should toggle between enabled and disabled</li>
+        </ol>
+    </div>
+    
+    <div class="tap-area" id="tap-here">
+        <h2>Tap Here 5 Times</h2>
+        <p>Tap this area 5 times quickly to toggle MetaScan</p>
+    </div>
+    
+    <h2>Testing Notes:</h2>
+    <ul>
+        <li>The taps must be completed within 3 seconds</li>
+        <li>You should see progress notifications after some taps</li>
+        <li>When the sequence completes, you'll see a confirmation toast</li>
+        <li>The MetaScan panel should appear/disappear based on its current state</li>
+    </ul>
+    
+    <h2>Debugging:</h2>
+    <p>If you encounter issues, open the browser console (F12 or right-click > Inspect > Console) to see log messages.</p>
+    
+    <!-- Load MetaScan script -->
+    <script src="./dist/auto.global.js" data-auto-enable="true"></script>
+</body>
+</html>


### PR DESCRIPTION
Implemented a mobile-friendly feature to enable/disable MetaScan by tapping
5 times anywhere on the page within 3 seconds.

Changes include:
- Created tap-detector.ts utility to track and process tap sequences
- Added Toast component for visual feedback during tap sequence
- Enhanced enableOrDisable function to properly update UI state
- Created test-page.html for feature testing
- Updated README with comprehensive documentation

This feature makes MetaScan more accessible on mobile devices where
accessing the console isn't practical. Users receive visual feedback
during the tap sequence and a confirmation when MetaScan is toggled.