### PR TITLE
feat: Add visual indicators for missing critical metadata tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ MetaScan is a lightweight (31.2 kB) client-side JavaScript tool that extracts an
 - 🚀 Zero-dependency with minimal footprint
 - 🔌 Simple installation with a single script tag
 - 🔍 Comprehensive metadata extraction with standardized keys and missing tag detection
+- 🚨 Visual indicator for missing critical metadata with count badge
 - 🎨 Clean, modern UI with dark/light mode support and smooth theme transition animations
 - 🎛️ Configurable positioning on any corner of the screen with improved dropdown positioning
 - 📋 Copy functionality for metadata values with standardized formatting
@@ -32,6 +33,7 @@ MetaScan is designed to serve the needs of various professionals working with we
 
 ### Web Developers
 - **Verify Metadata Implementation** - Instantly check metadata implementation during development
+- **Identify Missing Critical Tags** - Quickly spot missing critical metadata with visual indicators and counts
 - **Solve Structured Data Issues** - Resolve structured data problems without external tools
 - **Implement Open Graph and Twitter Card Tags** - Ensure correct implementation of Open Graph and Twitter Card tags
 - **Test Responsive Behavior** - Test metadata responsiveness across all devices
@@ -191,6 +193,8 @@ MetaScan helps identify missing metadata with an enhanced priority-based display
 - Identifies missing required metadata based on best practices
 - Shows standardized key names for easy implementation
 - Provides clear descriptions of why each tag is important
+- Displays a red badge with count of missing critical tags on the MetaScan icon
+- Shows the exact count of missing critical tags in the panel footer
 - Helps maintain metadata consistency across pages
 
 ## Extracted Metadata

--- a/public/index.html
+++ b/public/index.html
@@ -109,7 +109,7 @@
     <button id="log-metadata">Log Metadata</button>
     <script
       src="../dist/auto.global.js?meta-scan"
-      data-auto-enable="false"
+      data-auto-enable="true"
     ></script>
     <script>
       document

--- a/src/ui/MetadataLayout.tsx
+++ b/src/ui/MetadataLayout.tsx
@@ -1014,7 +1014,16 @@ const MetadataLayout = ({
         Data extracted at {new Date(metadata.extractedAt).toLocaleTimeString()}
         {metadata.missing?.hasCritical && (
           <span className="ml-2 text-red-500 dark:text-red-400 font-medium">
-            • Critical tags missing
+            • {(() => {
+              // Count critical missing tags across all categories
+              const criticalCount = [
+                ...metadata.missing.general,
+                ...metadata.missing.opengraph,
+                ...metadata.missing.twitter,
+                ...metadata.missing.technical
+              ].filter(tag => tag.importance === 'critical').length;
+              return criticalCount;
+            })()} Critical tags missing
           </span>
         )}
       </div>

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -285,6 +285,20 @@ export function App({ initialMetadata }: { initialMetadata: MetadataResult }) {
           }
         >
           {uiState.isOpen ? <CloseIcon /> : <MenuIcon />}
+          {!uiState.isOpen && metadata.missing?.hasCritical && (
+            <span className="absolute -top-1 -right-1 flex items-center justify-center bg-red-500 text-white text-xs font-bold rounded-full w-4 h-4">
+              {(() => {
+                // Count critical missing tags across all categories
+                const criticalCount = [
+                  ...metadata.missing.general,
+                  ...metadata.missing.opengraph,
+                  ...metadata.missing.twitter,
+                  ...metadata.missing.technical
+                ].filter(tag => tag.importance === 'critical').length;
+                return criticalCount;
+              })()}
+            </span>
+          )}
         </button>
       </div>
     </div>

--- a/test/pages/test-missing-tags.html
+++ b/test/pages/test-missing-tags.html
@@ -4,7 +4,7 @@
     <!-- Include MetaScan -->
     <script
       src="/dist/auto.global.js?meta-scan"
-      data-auto-enable="false"
+      data-auto-enable="true"
     ></script>
     <title>MetaScan Test Page</title>
     <meta charset="utf-8" />


### PR DESCRIPTION
- Add red badge with count to the MetaScan "M" icon when critical tags are missing
- Display the exact count of missing critical tags in the panel footer
- Update README to document the new feature
- Improve user experience by making metadata issues more visible at a glance

This enhancement helps users quickly identify when critical metadata is missing,
even when the panel is closed, and provides an immediate visual indication of
how many critical issues need to be addressed.